### PR TITLE
Workaround to serve images through CDN

### DIFF
--- a/app/controllers/comfy/admin/cms/files_controller.rb
+++ b/app/controllers/comfy/admin/cms/files_controller.rb
@@ -72,7 +72,7 @@ class Comfy::Admin::Cms::FilesController < Comfy::Admin::Cms::BaseController
       render partial: "file", object: @file
     when "redactor"
       render json: {
-        filelink: url_for_cms(@file.attachment),
+        filelink: url_for(@file.attachment),
         filename: @file.attachment.filename
       }
     else

--- a/app/controllers/comfy/admin/cms/files_controller.rb
+++ b/app/controllers/comfy/admin/cms/files_controller.rb
@@ -23,15 +23,15 @@ class Comfy::Admin::Cms::FilesController < Comfy::Admin::Cms::BaseController
         case params[:type]
         when "image"
           file_scope.with_images.collect do |file|
-            { thumb: url_for(file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:redactor])),
-              image: url_for(file.attachment),
+            { thumb: url_for_cms(file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:redactor])),
+              image: url_for_cms(file.attachment),
               title: file.label }
           end
         else
           file_scope.collect do |file|
             { title:  file.label,
               name:   file.attachment.filename,
-              link:   url_for(file.attachment),
+              link:   url_for_cms(file.attachment),
               size:   number_to_human_size(file.attachment.byte_size) }
           end
         end
@@ -72,7 +72,7 @@ class Comfy::Admin::Cms::FilesController < Comfy::Admin::Cms::BaseController
       render partial: "file", object: @file
     when "redactor"
       render json: {
-        filelink: url_for(@file.attachment),
+        filelink: url_for_cms(@file.attachment),
         filename: @file.attachment.filename
       }
     else

--- a/app/controllers/comfy/admin/cms/files_controller.rb
+++ b/app/controllers/comfy/admin/cms/files_controller.rb
@@ -23,15 +23,15 @@ class Comfy::Admin::Cms::FilesController < Comfy::Admin::Cms::BaseController
         case params[:type]
         when "image"
           file_scope.with_images.collect do |file|
-            { thumb: url_for_cms(file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:redactor])),
-              image: url_for_cms(file.attachment),
+            { thumb: helpers.url_for_cms(file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:redactor])),
+              image: helpers.url_for_cms(file.attachment),
               title: file.label }
           end
         else
           file_scope.collect do |file|
             { title:  file.label,
               name:   file.attachment.filename,
-              link:   url_for_cms(file.attachment),
+              link:   helpers.url_for_cms(file.attachment),
               size:   number_to_human_size(file.attachment.byte_size) }
           end
         end

--- a/app/controllers/comfy/admin/cms/files_controller.rb
+++ b/app/controllers/comfy/admin/cms/files_controller.rb
@@ -72,7 +72,7 @@ class Comfy::Admin::Cms::FilesController < Comfy::Admin::Cms::BaseController
       render partial: "file", object: @file
     when "redactor"
       render json: {
-        filelink: url_for(@file.attachment),
+        filelink: helpers.url_for_cms(@file.attachment),
         filename: @file.attachment.filename
       }
     else

--- a/app/helpers/comfy/cms_helper.rb
+++ b/app/helpers/comfy/cms_helper.rb
@@ -3,9 +3,9 @@
 module Comfy
   module CmsHelper
 
-    def url_for_cms(blob)
+    def url_for_cms(blob, only_path: true)
       if Rails.env.test?
-        Rails.application.routes.url_helpers.url_for(blob)
+        Rails.application.routes.url_helpers.url_for(blob, only_path)
       end
 
       if blob.is_a?(ActiveStorage::Variant)

--- a/app/helpers/comfy/cms_helper.rb
+++ b/app/helpers/comfy/cms_helper.rb
@@ -2,10 +2,13 @@
 
 module Comfy
   module CmsHelper
-
-    def url_for_cms(blob, only_path: true)
+    def url_for_cms(blob)
       if Rails.env.test?
-        Rails.application.routes.url_helpers.url_for(blob, only_path)
+        if blob.is_a?(ActiveStorage::Variant)
+          return rails_representation_path(blob, only_path: true)
+        else
+          return rails_blob_path(blob, only_path: true)
+        end
       end
 
       if blob.is_a?(ActiveStorage::Variant)

--- a/app/helpers/comfy/cms_helper.rb
+++ b/app/helpers/comfy/cms_helper.rb
@@ -5,7 +5,7 @@ module Comfy
 
     def url_for_cms(blob)
       if Rails.env.test?
-        super(blob)
+        Rails.application.routes.url_helpers.url_for(blob)
       end
 
       if blob.is_a?(ActiveStorage::Variant)

--- a/app/helpers/comfy/cms_helper.rb
+++ b/app/helpers/comfy/cms_helper.rb
@@ -3,6 +3,18 @@
 module Comfy
   module CmsHelper
 
+    def url_for_cms(blob)
+      if Rails.env.test?
+        super(blob)
+      end
+
+      if blob.is_a?(ActiveStorage::Variant)
+        return Rails.application.routes.url_helpers.rails_public_blob_url(blob.blob)
+      end
+
+      Rails.application.routes.url_helpers.rails_public_blob_url(blob)
+    end
+
     # Raw content of a page fragment. This is how you get content from unrenderable
     # tags like {{cms:fragment meta, render: false}}
     # Example:

--- a/app/views/comfy/admin/cms/files/_file.html.haml
+++ b/app/views/comfy/admin/cms/files/_file.html.haml
@@ -1,7 +1,7 @@
 %li{data: {id: file.id}}
   :ruby
     file_tag  = cms_file_link_tag(file)
-    thumb_url = url_for(file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb])) if file.attachment.variable?
+    thumb_url = url_for_cms(file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb])) if file.attachment.variable?
   .row
     .col-md-5.item
       .item-controls.d-none.d-lg-block

--- a/app/views/comfy/admin/cms/fragments/_form_fragment_attachments.html.haml
+++ b/app/views/comfy/admin/cms/fragments/_form_fragment_attachments.html.haml
@@ -2,7 +2,7 @@
   - attachments.each do |attachment|
     :ruby
       thumb_url = if attachment.variable?
-        url_for(attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb]))
+        url_for_cms(attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb]))
       end
       filename = attachment.filename.to_s
       truncated_filename = truncate(filename, length: 40, omission: "...#{filename.last(10)}")

--- a/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
@@ -1,19 +1,26 @@
+#require 'app/helpers/comfy/cms_helper.rb'
+
 # frozen_string_literal: true
 
 # A mixin for tags that returns the file as their content.
 module ComfortableMexicanSofa::Content::Tag::Mixins
   module FileContent
+    def url_for_cms(blob)
+      url_helpers = Rails.application.routes.url_helpers
 
-    def url_for_cms(blob, only_path = true)
       if Rails.env.test?
-        return Rails.application.routes.url_helpers.url_for(blob, only_path)
+        if blob.is_a?(ActiveStorage::Variant)
+          return url_helpers.rails_representation_path(blob, only_path: true)
+        else
+          return url_helpers.rails_blob_path(blob, only_path: true)
+        end
       end
 
       if blob.is_a?(ActiveStorage::Variant)
-        return Rails.application.routes.url_helpers.rails_public_blob_url(blob.blob)
+        return url_helpers.rails_public_blob_url(blob.blob)
       end
 
-      Rails.application.routes.url_helpers.rails_public_blob_url(blob)
+      url_helpers.rails_public_blob_url(blob)
     end
 
     # @param [ActiveStorage::Blob] file
@@ -27,9 +34,9 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
       attachment_url =
         if variant_attrs.present? && file.image?
           variant = file.variant(combine_options: variant_attrs)
-          url_for_cms(variant, only_path: true)
+          url_for_cms(variant)
         else
-          url_for_cms(file, only_path: true)
+          url_for_cms(file)
         end
 
       case as

--- a/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
@@ -4,6 +4,18 @@
 module ComfortableMexicanSofa::Content::Tag::Mixins
   module FileContent
 
+    def url_for_cms(blob, only_path = true)
+      if Rails.env.test?
+        return Rails.application.routes.url_helpers.url_for(blob, only_path)
+      end
+
+      if blob.is_a?(ActiveStorage::Variant)
+        return Rails.application.routes.url_helpers.rails_public_blob_url(blob.blob)
+      end
+
+      Rails.application.routes.url_helpers.rails_public_blob_url(blob)
+    end
+
     # @param [ActiveStorage::Blob] file
     # @param ["link", "image", "url"] as
     # @param [{String => String}] variant_attrs ImageMagick variant attributes
@@ -12,14 +24,12 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
     def content(file: self.file, as: self.as, variant_attrs: self.variant_attrs, label: self.label)
       return "" unless file
 
-      url_helpers = Rails.application.routes.url_helpers
-
       attachment_url =
         if variant_attrs.present? && file.image?
           variant = file.variant(combine_options: variant_attrs)
-          url_helpers.rails_representation_path(variant, only_path: true)
+          url_for_cms(variant, only_path: true)
         else
-          url_helpers.rails_blob_path(file, only_path: true)
+          url_for_cms(file, only_path: true)
         end
 
       case as

--- a/test/controllers/comfy/admin/cms/files_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/files_controller_test.rb
@@ -48,8 +48,8 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal [{
-      "thumb" => url_for(@file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:redactor])),
-      "image" => url_for(@file.attachment),
+      "thumb" => url_for_cms(@file.attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:redactor])),
+      "image" => url_for_cms(@file.attachment),
       "title" => @file.label
     }], JSON.parse(response.body)
   end
@@ -63,7 +63,7 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionDispatch::IntegrationTest
     assert_equal [{
       "title" => @file.label,
       "name"  => @file.attachment.filename.to_s,
-      "link"  => url_for(@file.attachment),
+      "link"  => url_for_cms(@file.attachment),
       "size"  => "12.1 KB"
     }], JSON.parse(response.body)
   end
@@ -172,7 +172,7 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionDispatch::IntegrationTest
 
       file = Comfy::Cms::File.last
       assert_equal ({
-        "filelink" => url_for(file.attachment),
+        "filelink" => url_for_cms(file.attachment),
         "filename" => file.attachment.filename
       }), JSON.parse(response.body)
 

--- a/test/controllers/comfy/admin/cms/files_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/files_controller_test.rb
@@ -172,7 +172,7 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionDispatch::IntegrationTest
 
       file = Comfy::Cms::File.last
       assert_equal ({
-        "filelink" => url_for_cms(file.attachment),
+        "filelink" => url_for(file.attachment),
         "filename" => file.attachment.filename
       }), JSON.parse(response.body)
 

--- a/test/controllers/comfy/admin/cms/files_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/files_controller_test.rb
@@ -3,6 +3,7 @@
 require_relative "../../../../test_helper"
 
 class Comfy::Admin::Cms::FilesControllerTest < ActionDispatch::IntegrationTest
+  include Comfy::CmsHelper
 
   def setup
     @site = comfy_cms_sites(:default)

--- a/test/controllers/comfy/admin/cms/files_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/files_controller_test.rb
@@ -173,7 +173,7 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionDispatch::IntegrationTest
 
       file = Comfy::Cms::File.last
       assert_equal ({
-        "filelink" => url_for(file.attachment),
+        "filelink" => url_for_cms(file.attachment),
         "filename" => file.attachment.filename
       }), JSON.parse(response.body)
 

--- a/test/helpers/cms_helper_test.rb
+++ b/test/helpers/cms_helper_test.rb
@@ -82,7 +82,7 @@ class CmsHelperTest < ActionView::TestCase
   def test_cms_fragment_render_with_files
     frag = comfy_cms_fragments(:file)
     comfy_cms_layouts(:default).update_column(:content, "{{cms:file file}}")
-    assert_equal url_for(frag.attachments.first), cms_fragment_render(:file)
+    assert_equal url_for_cms(frag.attachments.first), cms_fragment_render(:file)
   end
 
   def test_cms_snippet_content

--- a/test/integration/seeds_test.rb
+++ b/test/integration/seeds_test.rb
@@ -36,7 +36,7 @@ class SeedsIntergrationTest < ActionDispatch::IntegrationTest
           assert_equal "Default Seed Layout", Comfy::Cms::Layout.find_by_identifier("default").label
           assert_equal "Default Seed Snippet", Comfy::Cms::Snippet.find_by_identifier("default").label
 
-          file_path = url_for(ActiveStorage::Blob.find_by(filename: "header.png"))
+          file_path = url_for_cms(ActiveStorage::Blob.find_by(filename: "header.png"))
           file_path = file_path.sub("http://www.example.com", "")
           out = <<~HTML
             <html>

--- a/test/integration/seeds_test.rb
+++ b/test/integration/seeds_test.rb
@@ -3,6 +3,7 @@
 require_relative "../test_helper"
 
 class SeedsIntergrationTest < ActionDispatch::IntegrationTest
+  include Comfy::CmsHelper
 
   setup do
     @site = comfy_cms_sites(:default)

--- a/test/lib/form_builder_test.rb
+++ b/test/lib/form_builder_test.rb
@@ -149,8 +149,8 @@ class FormBuilderTest < ActionView::TestCase
     actual = @builder.fragment_field(tag, 123)
 
     attachment = active_storage_attachments(:file)
-    attachment_url  = view.url_for(attachment)
-    thumb_url       = view.url_for(attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb]))
+    attachment_url  = view.url_for_cms(attachment)
+    thumb_url       = view.url_for_cms(attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb]))
 
     expected = <<~HTML
       <div class="form-group row">
@@ -196,8 +196,8 @@ class FormBuilderTest < ActionView::TestCase
     actual = @builder.fragment_field(tag, 123)
 
     attachment = active_storage_attachments(:file)
-    attachment_url  = view.url_for(attachment)
-    thumb_url       = view.url_for(attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb]))
+    attachment_url  = view.url_for_cms(attachment)
+    thumb_url       = view.url_for_cms(attachment.variant(combine_options: Comfy::Cms::File::VARIANT_SIZE[:thumb]))
 
     expected = <<~HTML
       <div class="form-group row">


### PR DESCRIPTION
### Summary

Ticket reference [#40574](https://tickets.vivino.com/issues/40574)

Workaround to serve ActiveStorage uploads through a CDN. We'll have to get rid of this when we upgrade to Rails 6.1

**Please note** => `rails_public_blob` must be a method defined in the parent project (in this case, ruby-web)
