### PR TITLE
Security lib upgrades

### DIFF
--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "active_link_to",        ">= 1.0.0"
+  s.add_dependency "activerecord",          ">= 5.2.4.5", "< 5.2.5"
   s.add_dependency "comfy_bootstrap_form",  ">= 4.0.0"
   s.add_dependency "haml-rails",            ">= 1.0.0"
   s.add_dependency "jquery-rails",          ">= 4.3.1"

--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "comfy_bootstrap_form",  ">= 4.0.0"
   s.add_dependency "haml-rails",            ">= 1.0.0"
   s.add_dependency "jquery-rails",          ">= 4.3.1"
-  s.add_dependency "kramdown",              ">= 1.0.0"
+  s.add_dependency "kramdown",              ">= 2.3.1"
   s.add_dependency "mimemagic",             ">= 0.3.2"
   s.add_dependency "mini_magick",           ">= 4.8.0"
   s.add_dependency "rails",                 ">= 5.2.0"


### PR DESCRIPTION
Ticket reference: [#42859](https://tickets.vivino.com/issues/42859)

### Summary

Upgrade libs because of high risk security warnings